### PR TITLE
CT2L及びCT3のモデル名の修正

### DIFF
--- a/app/src/main/java/com/saradabar/cpadcustomizetool/MainActivity.java
+++ b/app/src/main/java/com/saradabar/cpadcustomizetool/MainActivity.java
@@ -322,7 +322,7 @@ public class MainActivity extends Activity implements UpdateEventListener {
 
     /* 端末チェック */
     private boolean checkModel() {
-        String[] modelName = {"TAB-A03-BS", "TAB-A03-BR", "TAB-A03-BR2", "TAB-A03-BR2B", "TAB-A03-BR3", "TAB-A04-BR3", "TAB-A05-BD", "TAB-A05-BA1"};
+        String[] modelName = {"TAB-A03-BS", "TAB-A03-BR", "TAB-A03-BR2", "TAB-A03-BR3", "TAB-A05-BD", "TAB-A05-BA1"};
         for (String string : modelName) if (Objects.equals(string, Build.MODEL)) return true;
         return false;
     }
@@ -343,7 +343,6 @@ public class MainActivity extends Activity implements UpdateEventListener {
         if (!Preferences.GET_DCHASERVICE_FLAG(this)) {
             switch (Build.MODEL) {
                 case "TAB-A03-BR3":
-                case "TAB-A04-BR3":
                     checkSettingsTab3();
                     break;
                 case "TAB-A05-BD":
@@ -369,7 +368,6 @@ public class MainActivity extends Activity implements UpdateEventListener {
                         Preferences.SET_DCHASERVICE_FLAG(false, this);
                         switch (Build.MODEL) {
                             case "TAB-A03-BR3":
-                            case "TAB-A04-BR3":
                                 checkSettingsTab3();
                                 break;
                             case "TAB-A05-BD":
@@ -387,7 +385,6 @@ public class MainActivity extends Activity implements UpdateEventListener {
 
         switch (Build.MODEL) {
             case "TAB-A03-BR3":
-            case "TAB-A04-BR3":
                 checkSettingsTab3();
                 break;
             case "TAB-A05-BD":


### PR DESCRIPTION
`ro.product.model`で取得される値は､
CT2Lb(`TAB-A03-BR2B`)の場合､ CT2L(`TAB-A03-BR2`)と同じ値です｡  
CT3の場合､ `TAB-A04-BR3`は､ `TAB-A03-BR3`と返ってきます｡

以前([#1 (comment)](https://github.com/Kobold831/CPadCustomizeTool/pull/1#issuecomment-1757704362))述べた通りですので､ ご確認願います｡
